### PR TITLE
Make the script retry parts that sometimes timeout on their connection

### DIFF
--- a/app.py
+++ b/app.py
@@ -104,18 +104,16 @@ def get_key(url: str) -> bytes:
     return resp.content
 
 @retry(stop=stop_after_attempt(3), wait=wait_fixed(3),
-         retry=retry_if_exception_type(requests.exceptions.ConnectionError))
+         retry=retry_if_exception_type(requests.exceptions.ConnectionError),
+         after=lambda s: click.echo(f" Retrying connection, attempt #{s.attempt_number}"))
 def make_cipher_for_segment(segment):
     """
     Initialize an AES decryptor.
     """
-    try:
-        key = get_key(segment.key.absolute_uri)
-        iv = bytes.fromhex(segment.key.iv.lstrip('0x'))
-        return AES.new(key, AES.MODE_CBC, IV=iv)
-    except requests.exceptions.ConnectionError:
-        # click.echo(' - Connection error in make_cipher, retrying...')
-        raise 
+    key = get_key(segment.key.absolute_uri)
+    iv = bytes.fromhex(segment.key.iv.lstrip('0x'))
+    return AES.new(key, AES.MODE_CBC, IV=iv)
+    
 
 
 def convert_to_mp3(stream_path: Path) -> None:
@@ -144,14 +142,15 @@ def confirm_overwrite(overwrite: bool, path: Path) -> None:
         sys.exit(0)
 
 @retry(stop=stop_after_attempt(3), wait=wait_fixed(3),
-            retry=retry_if_exception_type(requests.exceptions.ConnectionError))
+            retry=retry_if_exception_type(requests.exceptions.ConnectionError),
+            after=lambda s: click.echo(f" Retrying connection, attempt #{s.attempt_number}"))
 def write_chunks(file, cipher, segment) -> None:
-    try:
-        for chunk in requests.get(segment.absolute_uri, stream=True):
-            file.write(cipher.decrypt(chunk)) 
-    except requests.exceptions.ConnectionError:
-        # click.echo(' - Connection error in write_chunks, retrying...')
-        raise
+    """ 
+    Write decrypted chunks to the file.
+    """
+    for chunk in requests.get(segment.absolute_uri, stream=True):
+        file.write(cipher.decrypt(chunk)) 
+    
 
 @click.command()
 @click.argument('audio_book_url')


### PR DESCRIPTION
While using the script, the connection would sometimes time out or fail on either the `cipher = make_cipher_for_segment(segment)`  line or on the 
```
for chunk in requests.get(segment.absolute_uri, stream=True):
    file.write(cipher.decrypt(chunk))
```
block. This commit will make the script retry these parts if they fail. This has fixed the script for me